### PR TITLE
Ease up usage of Forban on systems with python 2.x and 3.x

### DIFF
--- a/bin/forbanctl
+++ b/bin/forbanctl
@@ -46,10 +46,13 @@ except ConfigParser.NoOptionError:
     forbanpath = os.path.join(guesspath())
 
 def service_start(servicename = None):
+    python_executable = sys.executable
+    if python_executable is None:
+        python_executable = 'python'
     if servicename is not None:
         service = servicename+".py"
         servicepath = os.path.join(guesspath(),"bin",service)
-        proc =  subprocess.Popen(["python",servicepath])
+        proc =  subprocess.Popen([python_executable,servicepath])
         time.sleep(0.15)
         return proc.pid
     return False


### PR DESCRIPTION
On systems using python 3.x this allows one to run forban (eg.
'python2 bin/forbanctl start') without having to edit the file
and hard-code 'python2' in there.
