### PR TITLE
Port core Forban scripts to Python 3

### DIFF
--- a/bin/forban_announce.py
+++ b/bin/forban_announce.py
@@ -22,7 +22,7 @@ import time
 import os
 import logging
 import logging.handlers
-import ConfigParser
+import configparser
 
 def guesspath():
     pp = os.path.realpath(sys.argv[0])
@@ -30,37 +30,37 @@ def guesspath():
     bis = os.path.split(lpath[0])
     return bis[0]
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 config.read(os.path.join(guesspath(),"cfg","forban.cfg"))
 
 try:
     forbanpath = config.get('global','path')
-except ConfigParser.Error:
+except configparser.Error:
     forbanpath = os.path.join(guesspath())
 
 try:
     announceinterval = config.getint('global','announceinterval')
-except ConfigParser.Error:
+except configparser.Error:
     announceinterval = 10
 
 try:
     indexrebuild = config.getint('global','indexrebuild')
-except ConfigParser.Error:
+except configparser.Error:
     indexrebuild = 1
 
 try:
     forbanshareroot = config.get('forban','share')
-except ConfigParser.Error:
+except configparser.Error:
     forbanshareroot = os.path.join(forbanpath,"var","share/")
 
 try:
     forbanlogginglevel = config.get('global','logging')
-except ConfigParser.Error:
+except configparser.Error:
     forbanlogginglevel = "INFO"
 
 try:
     forbanloggingsize = config.get('global','loggingmaxsize')
-except ConfigParser.Error:
+except configparser.Error:
     forbanloggingsize = 100000
 
 
@@ -93,13 +93,13 @@ if __name__ == "__main__":
 
     try:
         forbanname = config.get('global','name')
-    except ConfigParser.Error:
+    except configparser.Error:
         forbanname = tools.guesshostname()
 
     try:
         ipv6_disabled =  config.get('global' , 'disabled_ipv6')
-	flogger.debug ( "Read ipv6_disabled")
-    except  ConfigParser.Error:
+        flogger.debug("Read ipv6_disabled")
+    except  configparser.Error:
         ipv6_disabled = 0
 
     msg = announce.message(name=forbanname, dynpath=os.path.join(forbanpath,"var"))
@@ -112,7 +112,7 @@ if __name__ == "__main__":
         destination =  config.get('global' , 'destination')
         flogger.debug( "Read custom destinations: >"+ destination + "< ")
         msg.setDestination( eval ( destination ) )
-    except  ConfigParser.Error:
+    except  configparser.Error:
         msg.setDestination()
 
     forbanindex = index.manage(sharedir=forbanshareroot, forbanglobal=forbanpath)

--- a/bin/forban_discover.py
+++ b/bin/forban_discover.py
@@ -19,7 +19,7 @@
 
 import sys
 import os
-import ConfigParser
+import configparser
 
 def guesspath():
     pp = os.path.realpath(sys.argv[0])
@@ -27,24 +27,24 @@ def guesspath():
     bis = os.path.split(lpath[0])
     return bis[0]
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 config.read(os.path.join(guesspath(),"cfg","forban.cfg"))
 
 try:
     disable_ipv6 =  config.get('global','disabled_ipv6')
-except ConfigParser.NoOptionError:
+except configparser.NoOptionError:
     disable_ipv6 = 0
-except ConfigParser.NoSectionError:
+except configparser.NoSectionError:
     disable_ipv6 = 0
 
 try:
     forbanpath = config.get('global','path')
-except ConfigParser.NoSectionError:
-    print "Forban config file is missing or incorrect"
-    print "You should go into ../cfg/ and cp forban.cfg-sample forban.cfg"
-    print "In any case, Forban should be able to work even without the config file"
+except configparser.NoSectionError:
+    print("Forban config file is missing or incorrect")
+    print("You should go into ../cfg/ and cp forban.cfg-sample forban.cfg")
+    print("In any case, Forban should be able to work even without the config file")
     forbanpath = os.path.join(guesspath())
-except ConfigParser.NoOptionError:
+except configparser.NoOptionError:
     forbanpath = os.path.join(guesspath())
 
 forbanpathlib = os.path.join(forbanpath,"lib")
@@ -58,9 +58,9 @@ if __name__ == "__main__":
     while 1:
         HOST, PORT = ("", 12555)
         server = discover.UDPServer((HOST, PORT), discover.MyUDPHandler)
-	if disable_ipv6 == "1":
-              server.setIPv6 ( 0 )
-	else:
-              server.setIPv6 ( 1 )
+        if disable_ipv6 == "1":
+            server.setIPv6(0)
+        else:
+            server.setIPv6(1)
         server.serve_forever()
 

--- a/bin/forban_opportunistic.py
+++ b/bin/forban_opportunistic.py
@@ -22,7 +22,7 @@ import os.path
 import sys
 import string
 import time
-import ConfigParser
+import configparser
 import re
 import logging
 import logging.handlers
@@ -33,20 +33,20 @@ def guesspath():
     bis = os.path.split(lpath[0])
     return bis[0]
 
-config = ConfigParser.RawConfigParser()
+config = configparser.RawConfigParser()
 config.read(os.path.join(guesspath(),"cfg","forban.cfg"))
 
 
 try:
     forbanpath = config.get('global','path')
-except ConfigParser.Error:
+except configparser.Error:
     forbanpath = os.path.join(guesspath())
 
 try:
     forbanshareroot = config.get('forban','share')
-except ConfigParser.Error:
+except configparser.Error:
     forbanshareroot = os.path.join(forbanpath,"var","share/")
-except ConfigParser.NoOptionError:
+except configparser.NoOptionError:
     forbanpath = os.path.join(guesspath())
     forbanshareroot = os.path.join(forbanpath,"var","share/")
 
@@ -59,29 +59,29 @@ import base64e
 
 try:
     forbanmode = config.get('global','mode')
-except ConfigParser.Error:
+except configparser.Error:
     forbanmode = "opportunistic"
 
 if not forbanmode == "opportunistic":
-    print "not configured in opportunistic mode"
+    print("not configured in opportunistic mode")
     exit(1)
 
 
 try:
     announceinterval = config.get('global','announceinterval')
-except ConfigParser.Error:
+except configparser.Error:
     announceinterval = 10
 
 announceinterval = float(announceinterval)
 
 try:
     forbanlogginglevel = config.get('global','logging')
-except ConfigParser.Error:
+except configparser.Error:
     forbanlogginglevel = "INFO"
 
 try:
     forbanloggingsize = config.get('global','loggingmaxsize')
-except ConfigParser.Error:
+except configparser.Error:
     forbanloggingsize = 100000
 
 forbanpathlog=os.path.join(forbanpath,"var","log")
@@ -104,12 +104,12 @@ flogger.addHandler(handler)
 
 try:
     ofilter = config.get('opportunistic','filter')
-except ConfigParser.Error:
+except configparser.Error:
     ofilter = ""
 
 try:
     efilter = config.get('opportunistic','efilter')
-except ConfigParser.Error:
+except configparser.Error:
     efilter = None
 
 refilter = re.compile(ofilter, re.I)
@@ -120,7 +120,7 @@ else:
 
 try:
     maxsize = config.get('opportunistic','maxsize')
-except ConfigParser.Error:
+except configparser.Error:
     maxsize = 0
 
 discoveredloot = loot.loot(dynpath=os.path.join(forbanpath,"var"))

--- a/lib/announce.py
+++ b/lib/announce.py
@@ -77,20 +77,20 @@ class message:
         if  flogger is not None:
             flogger.debug ( msg )
         elif debug == 1:
-            print msg
+            print(msg)
 
     def __errorMessage (self, msg):
         if flogger is not None:
             flogger.error ( msg )
         elif debug == 1:
-            print msg
+            print(msg)
 
 
     def send(self):
         for destination in self.destination:
             if socket.has_ipv6 and re.search(":", destination) and not  self.ipv6_disabled == 1:
                
-		self.__debugMessage(  "working in ipv6 part on destination " + destination )
+                self.__debugMessage("working in ipv6 part on destination " + destination)
 
                 # Even if Python is compiled with IPv6, it doesn't mean that the os
                 # is supporting IPv6. (like the Nokia N900)
@@ -108,8 +108,8 @@ class message:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
             try:
-                sock.sendto(self.payload, (destination, int(self.port)))
-            except socket.error, msg:
+                sock.sendto(self.payload.encode("utf-8"), (destination, int(self.port)))
+            except socket.error as msg:
                 self.__errorMessage ( "Error sending to "+ destination + " : " + msg.strerror  )
                 continue
         sock.close()
@@ -120,10 +120,10 @@ def managetest():
     msg = message()
     msg.gen()
     msg.auth()
-    print msg.get()
+    print((msg.get()))
     msg.send()
     msg.auth("forbankey")
-    print msg.get()
+    print((msg.get()))
 
 if __name__ == "__main__":
     managetest()

--- a/lib/base64e.py
+++ b/lib/base64e.py
@@ -19,18 +19,19 @@
 
 import base64
 
-def encode( istring ):
-    b64s = base64.urlsafe_b64encode(istring)
-    b64s = b64s.replace("=","!")
-    return b64s
+def encode(istring):
+    if isinstance(istring, str):
+        istring = istring.encode("utf-8")
+    b64s = base64.urlsafe_b64encode(istring).decode("ascii")
+    return b64s.replace("=", "!")
 
-def decode( istring ):
-    istring = istring.replace("!","=")
-    b64s = base64.urlsafe_b64decode(istring.encode("utf-8"))
-    return b64s
+def decode(istring):
+    istring = istring.replace("!", "=")
+    b64s = base64.urlsafe_b64decode(istring.encode("ascii"))
+    return b64s.decode("utf-8")
 
 if __name__ == "__main__":
     encodedone = encode("some string with")
-    print encodedone
+    print(encodedone)
     decodedone = decode(encodedone)
-    print decodedone
+    print(decodedone)

--- a/lib/discover.py
+++ b/lib/discover.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import SocketServer
+import socketserver
 import socket
 import sys
 import os
@@ -33,18 +33,20 @@ def guesspath():
 
 forbanpath = os.path.join(guesspath())
 
-class MyUDPHandler(SocketServer.BaseRequestHandler):
+class MyUDPHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
         data = self.request[0].strip()
+        if isinstance(data, bytes):
+            data = data.decode("utf-8", errors="ignore")
         socket = self.request[1]
         if data[:6] == "forban":
             myloot = loot.loot(dynpath=os.path.join(forbanpath,"var"))
             myloot.add(data, self.client_address[0])
         else:
-            print "debug : not a forban message"
+            print("debug : not a forban message")
 
-class UDPServer(SocketServer.UDPServer):
+class UDPServer(socketserver.UDPServer):
     
     def setIPv6 (self, ipv6 = 1 ):
         if  ipv6 == 0 :

--- a/lib/fetch.py
+++ b/lib/fetch.py
@@ -19,7 +19,7 @@
 
 import os
 import socket
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import shutil
 
 socket.setdefaulttimeout(10)
@@ -28,15 +28,15 @@ import tmpname
 import tools
 
 def urlheadinfo(url):
-    request = urllib2.Request(url)
+    request = urllib.request.Request(url)
     request.add_header('User-Agent','Forban +http://www.foo.be/forban/')
     request.get_method = lambda: "HEAD"
 
     try:
-        httphead = urllib2.urlopen(request)
-    except urllib2.HTTPError, e:
+        httphead = urllib.request.urlopen(request)
+    except urllib.error.HTTPError as e:
         return False
-    except urllib2.URLError, e:
+    except urllib.error.URLError as e:
         return False
     else:
         pass
@@ -44,16 +44,16 @@ def urlheadinfo(url):
     return (httphead.headers["last-modified"],httphead.headers["content-length"])
 
 def urlget(url, localfile="testurlget"):
-    httpreq = urllib2.Request(url)
+    httpreq = urllib.request.Request(url)
     httpreq.add_header('User-Agent','Forban +http://www.foo.be/forban/')
 
     try:
-        r = urllib2.urlopen(httpreq)
-    except urllib2.HTTPError, e:
+        r = urllib.request.urlopen(httpreq)
+    except urllib.error.HTTPError as e:
         return False
-    except urllib2.URLError, e:
+    except urllib.error.URLError as e:
         return False
-    except socket.error,e:
+    except socket.error as e:
         return False
     except socket.timeout:
         return False
@@ -73,10 +73,10 @@ def urlget(url, localfile="testurlget"):
 
     tlocalfile = tmpname.get(localfile)
 
-    if r.info().has_key('Content-Disposition'):
-        f = open (tlocalfile[1], "w")
+    if 'Content-Disposition' in r.info():
+        f = open(tlocalfile[1], "wb")
         try:
-            shutil.copyfileobj(r.fp,f)
+            shutil.copyfileobj(r, f)
         except:
             return False
         f.close()
@@ -87,7 +87,7 @@ def urlget(url, localfile="testurlget"):
         return False
 
 def managetest():
-    print urlget("http://127.0.0.1:12555/s/?g=forban/index")
+    print((urlget("http://127.0.0.1:12555/s/?g=forban/index")))
 
 if __name__ == "__main__":
     managetest()

--- a/lib/fid.py
+++ b/lib/fid.py
@@ -54,9 +54,9 @@ class manage:
 
 def managetest():
         fid = manage()
-        print fid.get()
+        print(fid.get())
         fid.regen()
-        print fid.get()
+        print(fid.get())
 
 if __name__ == "__main__":
 

--- a/lib/index.py
+++ b/lib/index.py
@@ -90,9 +90,8 @@ class manage:
 
         if not os.path.exists(filepath):
             return False
-        f = open (filepath,"r")
-        auth = hmac.new(key, f.read(), sha1)
-        f.close()
+        with open(filepath, "rb") as f:
+            auth = hmac.new(key.encode("utf-8"), f.read(), sha1)
 
         return auth.hexdigest()
 
@@ -203,14 +202,14 @@ class manage:
 def test ():
     testindex = manage()
     testindex.build()
-    print testindex.gethmac()
+    print((testindex.gethmac()))
 
     testindex.cache("8d63025e-2f11-4c08-837a-08c44b122150")
     #print testindex.howfar("e2f05993-eba1-4b94-8e56-d2157d1ce552")
     #print testindex.search("^((?!forban).)*$","e2f05993-eba1-4b94-8e56-d2157d1ce552");
-    print testindex.getfilesize(filename="forban/index")
-    print testindex.getfilesize(filename="forban//index",uuid="8d63025e-2f11-4c08-837a-08c44b122150")
-    print testindex.totalfilesize(uuid="d55727ed-5c6a-49a8-9d8d-28b4004aee0c")
+    print((testindex.getfilesize(filename="forban/index")))
+    print((testindex.getfilesize(filename="forban//index",uuid="8d63025e-2f11-4c08-837a-08c44b122150")))
+    print((testindex.totalfilesize(uuid="d55727ed-5c6a-49a8-9d8d-28b4004aee0c")))
 
 if __name__ == "__main__":
 

--- a/lib/loot.py
+++ b/lib/loot.py
@@ -274,13 +274,13 @@ def loottest():
 
         myloot = loot()
         if not myloot.exist("1234"):
-            print "not existing -> ok"
+            print("not existing -> ok")
         #myloot.add("forban;name;notset;uuid;cb001bf2-1497-443c-9675-74de7027ecf9;hmac;59753cbda00f8c605aff6c4ceacd3f12caedddea","127.0.0.1")
-        print myloot.getindexurl("cb001bf2-1497-443c-9675-74de7027ecf9")
-        print myloot.getlastseen("cb001bf2-1497-443c-9675-74de7027ecf9")
-        print myloot.lastannounced("cb001bf2-1497-443c-9675-74de7027ecf9")
-        print myloot.listall()
-        print myloot.gethmac("cb001bf2-1497-443c-9675-74de7027ecf9")
+        print((myloot.getindexurl("cb001bf2-1497-443c-9675-74de7027ecf9")))
+        print((myloot.getlastseen("cb001bf2-1497-443c-9675-74de7027ecf9")))
+        print((myloot.lastannounced("cb001bf2-1497-443c-9675-74de7027ecf9")))
+        print((myloot.listall()))
+        print((myloot.gethmac("cb001bf2-1497-443c-9675-74de7027ecf9")))
 
 if __name__ == "__main__":
 

--- a/lib/tmpname.py
+++ b/lib/tmpname.py
@@ -48,5 +48,5 @@ def get(filename=None, suff=None):
 
 if __name__ == "__main__":
     
-    print get("aest")[1]
-    print get("/a/b/aestb")
+    print(get("aest")[1])
+    print(get("/a/b/aestb"))

--- a/lib/tools.py
+++ b/lib/tools.py
@@ -117,7 +117,7 @@ def finddir(rootdir=None, dirmatch="forban"):
     return dirfound
 
 if __name__ == "__main__":
-   print convertbytes (1234567)
-   print guesshostname()
-   print finddir("/media")
+   print(convertbytes (1234567))
+   print(guesshostname())
+   print(finddir("/media"))
    # print rename("x","xy")


### PR DESCRIPTION
### Motivation
- Modernize the codebase for Python 3 so the CLI tools and core libraries run under current Python interpreters.
- Fix runtime issues caused by Python 2 idioms around text/bytes, networking and I/O that break behavior on Python 3.
- Eliminate parsing/runtime errors caused by mixed tabs/spaces and legacy exception/print syntax.
- Preserve existing protocol behavior (announce/discover/fetch/index) while making encoding and HMAC handling explicit for Python 3.

### Description
- Replaced Python 2 `ConfigParser` usage with Python 3 `configparser` and converted `print` statements to function form across entrypoints in `bin/` and helper modules in `lib/`.
- Updated HTTP fetching to use `urllib.request`/`urllib.error` with downloads written in binary (`open(..., 'wb')`) and `shutil.copyfileobj` copying from the response stream directly (`lib/fetch.py`).
- Made HMAC and index handling binary safe by reading index files in binary and using a byte-encoded key when calling `hmac.new` (`lib/index.py`).
- Fixed UDP/announce/discover bytes handling by encoding outgoing announce payloads to bytes before `sendto` and decoding incoming datagrams before string parsing, and resolved several indentation issues that caused parse errors (`lib/announce.py`, `lib/discover.py`, `bin/*`).
- Rewrote the Base64 URL-safe helper to handle `str`/`bytes` explicitly and return text suitable for URLs (`lib/base64e.py`).
- Minor Python 3 compatibility tweaks and cleanup in `lib/fid.py`, `lib/tmpname.py`, `lib/tools.py`, `lib/loot.py` and other scripts to ensure they compile under Python 3.

### Testing
- Ran a full syntax/compile pass with `py_compile` across all non-vendored Python modules (all `bin/*.py` and `lib/*.py` excluding `lib/ext/cherrypy`) which completed with zero failures.
- Performed a round-trip smoke test for base64 helpers using `base64e.encode`/`base64e.decode` which succeeded and returned the original string.
- Ran a smoke check of `index.manage().calchmac(...)` to verify HMAC path executes under Python 3 and returns the expected-length digest, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0929eaaac832494b9949c73698b14)